### PR TITLE
SCS-2492 Modify Java DDB Data Migration for use with On-Demand Tables

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 
 \.idea/
 target/
+.settings
+.classpath
+.project

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
         <url>https://github.com/awslabs/dynamodb-import-export-tool.git</url>
     </scm>
     <properties>
-        <aws.java.sdk.version>1.11.242</aws.java.sdk.version>
+        <aws.java.sdk.version>1.11.566</aws.java.sdk.version>
         <powermock.version>1.6.2</powermock.version>
         <jcommander.version>1.48</jcommander.version>
         <guava.version>23.6-jre</guava.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.amazonaws</groupId>
-    <version>1.1.0</version>
+    <version>1.2.0</version>
     <artifactId>dynamodb-import-export-tool</artifactId>
     <packaging>jar</packaging>
     <name>DynamoDB Import Export Tool</name>

--- a/src/main/java/com/amazonaws/dynamodb/bootstrap/CommandLineArgs.java
+++ b/src/main/java/com/amazonaws/dynamodb/bootstrap/CommandLineArgs.java
@@ -63,7 +63,7 @@ public class CommandLineArgs {
     }
 
     public static final String READ_THROUGHPUT_RATIO = "--readThroughputRatio";
-    @Parameter(names = READ_THROUGHPUT_RATIO, description = "Percentage of total read throughput to scan the source table", required = true)
+    @Parameter(names = READ_THROUGHPUT_RATIO, description = "Percentage of total read throughput to scan the source table", required = false)
     private double readThroughputRatio;
 
     public double getReadThroughputRatio() {
@@ -71,11 +71,19 @@ public class CommandLineArgs {
     }
 
     public static final String WRITE_THROUGHPUT_RATIO = "--writeThroughputRatio";
-    @Parameter(names = WRITE_THROUGHPUT_RATIO, description = "Percentage of total write throughput to write the destination table", required = true)
+    @Parameter(names = WRITE_THROUGHPUT_RATIO, description = "Percentage of total write throughput to write the destination table", required = false)
     private double writeThroughputRatio;
 
     public double getWriteThroughputRatio() {
         return writeThroughputRatio;
+    }
+
+    public static final String THROUGHPUT_RATE = "--throughputRate";
+    @Parameter(names = THROUGHPUT_RATE, description = "Arbitrary throughput rate to be used instead of ratios", required = false)
+    private double throughputRate;
+
+    public double getThroughputRate() {
+        return throughputRate;
     }
 
     public static final String MAX_WRITE_THREADS = "--maxWriteThreads";

--- a/src/main/java/com/amazonaws/dynamodb/bootstrap/CommandLineInterface.java
+++ b/src/main/java/com/amazonaws/dynamodb/bootstrap/CommandLineInterface.java
@@ -21,8 +21,6 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import com.amazonaws.auth.profile.ProfileCredentialsProvider;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDB;
-import com.amazonaws.services.dynamodbv2.AmazonDynamoDBClientBuilder;
 import com.google.common.base.Strings;
 import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
@@ -82,6 +80,7 @@ public class CommandLineInterface {
         final String sourceTable = params.getSourceTable();
         final double readThroughputRatio = params.getReadThroughputRatio();
         final double writeThroughputRatio = params.getWriteThroughputRatio();
+        final double throughputRate = params.getThroughputRate();
         final int maxWriteThreads = params.getMaxWriteThreads();
         final boolean consistentScan = params.getConsistentScan();
         final boolean crossAccount = params.getCrossAccount();
@@ -137,10 +136,17 @@ public class CommandLineInterface {
                     + numSegments, e);
         }
 
-        final double readThroughput = calculateThroughput(readTableDescription,
-                readThroughputRatio, true);
-        final double writeThroughput = calculateThroughput(
-                writeTableDescription, writeThroughputRatio, false);
+        double readThroughput, writeThroughput;
+        if (throughputRate == 0) {
+            readThroughput = calculateThroughput(readTableDescription,
+                    readThroughputRatio, true);
+            writeThroughput = calculateThroughput(
+                    writeTableDescription, writeThroughputRatio, false);
+        } else {
+            readThroughput = throughputRate;
+            writeThroughput = throughputRate;
+
+        }
 
         try {
             ExecutorService sourceExec = getSourceThreadPool(numSegments);


### PR DESCRIPTION
[SCS-2492](https://solutonashville.atlassian.net/browse/SCS-2492)

Added a parameter to set arbitrary throughput rate to use instead of capacity ratios.  This will allow usage of this utility with tables set to use on-demand capacity instead of the provisioned capacity.

Copy of all nonprod cloud SAL data was successful.

Going to do a test on a huge table to get some performance numbers.